### PR TITLE
feat(safari) support safari for audio recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ export default {
 }
 ```
 
+> We're using [this polyfill](https://github.com/kbumsik/opus-media-recorder) for Safari.
+
 ### Recording Video
 
 It's simple as adding the component and listening for the __result__ event:
@@ -96,6 +98,8 @@ export default {
   }
 }
 ```
+
+> It doesn't work on Safari, we should consider [this polyfill](https://github.com/CameraKit/webm-media-recorder).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2347,16 +2347,6 @@
       "integrity": "sha512-8VCoJeeH8tCkzhkpfOkt+abALQkS11OIHhte5MBzYaKMTqK0A3ZAKEUVAffsOklhEv7t0yrQt696Opnu9oAx+w==",
       "dev": true
     },
-    "@vue/test-utils": {
-      "version": "1.0.0-beta.29",
-      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.29.tgz",
-      "integrity": "sha512-yX4sxEIHh4M9yAbLA/ikpEnGKMNBCnoX98xE1RwxfhQVcn0MaXNSj1Qmac+ZydTj6VBSEVukchBogXBTwc+9iA==",
-      "dev": true,
-      "requires": {
-        "dom-event-types": "^1.0.0",
-        "lodash": "^4.17.4"
-      }
-    },
     "@vue/web-component-wrapper": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@vue/web-component-wrapper/-/web-component-wrapper-1.2.0.tgz",
@@ -5917,12 +5907,6 @@
       "requires": {
         "utila": "~0.4"
       }
-    },
-    "dom-event-types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dom-event-types/-/dom-event-types-1.0.0.tgz",
-      "integrity": "sha512-2G2Vwi2zXTHBGqXHsJ4+ak/iP0N8Ar+G8a7LiD2oup5o4sQWytwqqrZu/O6hIMV0KMID2PL69OhpshLO0n7UJQ==",
-      "dev": true
     },
     "dom-serializer": {
       "version": "0.2.1",
@@ -15759,6 +15743,11 @@
       "integrity": "sha512-Vx6W1Yvy+AM1R/ckVwcHQHV147pTPBKWCRLrXMuPrFVfvBUc3os7PR1QLIWCMhPpRg5eX9ojzbQIMLGBwyLjqg==",
       "dev": true
     },
+    "startaudiocontext": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/startaudiocontext/-/startaudiocontext-1.2.1.tgz",
+      "integrity": "sha1-RtLKtUYseRGArMciPju7wycshZU="
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -16517,6 +16506,11 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
+    },
+    "tone": {
+      "version": "13.8.25",
+      "resolved": "https://registry.npmjs.org/tone/-/tone-13.8.25.tgz",
+      "integrity": "sha512-8QqmLn+/R+Urib/78zf93+NqFLddXS777kQO7+EbJHwqy+nmug+SJFRp2KIytT0LQY2sJBiopNb2ceHA8uQQJg=="
     },
     "toposort": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "dist"
   ],
   "dependencies": {
+    "startaudiocontext": "^1.2.1",
+    "tone": "^13.8.25",
     "vue": "^2.0"
   },
   "devDependencies": {

--- a/src/components/ElementMixin.js
+++ b/src/components/ElementMixin.js
@@ -1,11 +1,19 @@
 import RecorderMixin from './RecorderMixin'
+import SafariRecorderMixin from './SafariRecorderMixin'
+
+const mixins = [RecorderMixin];
+
+if (!window.MediaRecorder) {
+  console.warn('Using Safari polyfill');
+  mixins.push(SafariRecorderMixin)
+}
 
 /**
  * The element mixin defines the mode behaviour and creates two
  * functions to start and stop the recording execution
  */
 export default {
-  mixins: [RecorderMixin],
+  mixins: mixins,
   props: {
     mode: {
       type: String,

--- a/src/components/RecorderMixin.js
+++ b/src/components/RecorderMixin.js
@@ -111,6 +111,14 @@ export default {
       return
     }
 
+    // video recorder on Safari is not currently supported
+    // TODO: we could use https://github.com/CameraKit/webm-media-recorder
+    if (!window.MediaRecorder && this.constraints.video) {
+      // eslint-disable-next-line
+      console.warn('MediaRecorder for video is not supported from your browser.')
+      return
+    }
+
     this.isSupported = true
   }
 }

--- a/src/components/SafariRecorderMixin.js
+++ b/src/components/SafariRecorderMixin.js
@@ -1,0 +1,204 @@
+import { loadScripts } from "./loadScripts";
+
+import StartAudioContext from "startaudiocontext";
+import Tone from "tone";
+
+export default {
+  methods: {
+    async start() {
+      if (this.isRecording) {
+        return;
+      }
+
+      try {
+        this.$_stream = await this.getStream();
+        await this.prepareRecorder();
+
+        this.$_mediaRecorder.start();
+        Tone.Transport.start();
+      } catch (e) {
+        this.$emit("error", e);
+        // eslint-disable-next-line
+        console.error(e);
+      }
+    },
+
+    stop() {
+      if (!this.isRecording) return;
+
+      this.$_mediaRecorder.stop();
+      this.$_stream.getTracks().forEach(t => t.stop());
+      this.$_mic.close();
+
+      Tone.Transport.stop();
+    },
+
+    /**
+     * Get the input stream based on constraints and emit the stream event
+     * to the parent component so he can use it for processing or show a preview
+     */
+    async getStream() {
+      // const stream = await navigator.mediaDevices.getUserMedia(this.constraints)
+      // this.$_stream = stream
+
+      // https://github.com/Tonejs/Tone.js/issues/341
+      // https://github.com/tambien/StartAudioContext
+      StartAudioContext(Tone.context);
+
+      // you probably DONT want to connect the microphone
+      // directly to the master output because of feedback.
+      this.$_mic = new Tone.UserMedia();
+      this.debug && console.log("tonejs microphone instance", this.$_mic);
+
+      await this.$_mic.open();
+      this.debug && console.log("mic is open", this.$_mic);
+
+      const dest = Tone.context.createMediaStreamDestination();
+      this.debug && console.log("context.createMediaStreamDestination", dest);
+
+      this.$_mic.connect(dest);
+      this.debug && console.log("mic connected");
+
+      this.$_stream = dest.stream;
+      this.$emit("stream", this.$_stream);
+
+      return this.$_stream;
+    },
+
+    /**
+     * Create a new media recorder with the user media stream
+     * and set some event listeners to update component data
+     * and emit events to the parent component
+     */
+    async prepareRecorder() {
+      if (!this.$_stream) {
+        return;
+      }
+
+      /*
+      <!-- load OpusMediaRecorder.umd.js. OpusMediaRecorder will be loaded. -->
+      <script src="https://cdn.jsdelivr.net/npm/opus-media-recorder@latest/OpusMediaRecorder.umd.js"></script>
+      <!-- load encoderWorker.umd.js. This should be after OpusMediaRecorder. -->
+      <!-- This script tag will create OpusMediaRecorder.encoderWorker. -->
+      <script src="https://cdn.jsdelivr.net/npm/opus-media-recorder@latest/encoderWorker.umd.js"></script>
+      <script>
+        // Check if MediaRecorder available.
+        if (!window.MediaRecorder) {
+          window.MediaRecorder = OpusMediaRecorder;
+        }
+        // Check if a target format (e.g. audio/ogg) is supported.
+        else if (!window.MediaRecorder.isTypeSupported('audio/ogg;codecs=opus')) {
+          window.MediaRecorder = OpusMediaRecorder;
+        }
+      </script>
+      <script type="text/javascript" src="//webrtchacks.github.io/adapter/adapter-latest.js"></script>
+      <!-- <script type="text/javascript" src="/js/audio-service/StartAudioContext.js"></script>
+      <script type="text/javascript" src="/js/audio-service/Tone.js"></script> -->
+      */
+
+      await loadScripts([
+        // load OpusMediaRecorder.umd.js. OpusMediaRecorder will be loaded.
+        "https://cdn.jsdelivr.net/npm/opus-media-recorder@latest/OpusMediaRecorder.umd.js",
+        // load encoderWorker.umd.js. This should be after OpusMediaRecorder.
+        // This script tag will create OpusMediaRecorder.encoderWorker.
+        "https://cdn.jsdelivr.net/npm/opus-media-recorder@latest/encoderWorker.umd.js",
+        "https://webrtchacks.github.io/adapter/adapter-latest.js"
+        // I've included NPM ones
+        // '/js/audio-service/StartAudioContext.js',
+        // '/js/audio-service/Tone.js',
+      ]);
+
+      let CustomMediaRecorder = window.MediaRecorder;
+
+      // Check if MediaRecorder available.
+      if (!CustomMediaRecorder) {
+        if (!window.OpusMediaRecorder) {
+          console.error('OpusMediaRecorder is not defined');
+        }
+
+        // eslint-disable-next-line no-undef
+        CustomMediaRecorder = OpusMediaRecorder;
+      }
+      // Check if a target format (e.g. audio/ogg) is supported.
+      else if (!CustomMediaRecorder.isTypeSupported("audio/ogg;codecs=opus")) {
+        if (!window.OpusMediaRecorder) {
+          console.error('OpusMediaRecorder is not defined');
+        }
+
+        // eslint-disable-next-line no-undef
+        CustomMediaRecorder = OpusMediaRecorder;
+      }
+
+      // If you already load encoderWorker.js using <script> tag,
+      // you don't need to define encoderWorkerFactory.
+      const workerOptions = {
+        OggOpusEncoderWasmPath:
+          "https://cdn.jsdelivr.net/npm/opus-media-recorder@latest/OggOpusEncoder.wasm",
+        WebMOpusEncoderWasmPath:
+          "https://cdn.jsdelivr.net/npm/opus-media-recorder@latest/WebMOpusEncoder.wasm"
+      };
+
+      this.$_mediaRecorder = new CustomMediaRecorder(
+        this.$_stream,
+        {
+          // mimeType: this.mimeType
+          mimeType: "" // browser dependent
+        },
+        workerOptions
+      );
+      this.debug && console.log("⏺", this.$_mediaRecorder);
+
+      this.$_mediaRecorder.ignoreMutedMedia = true;
+
+      this.$_mediaRecorder.addEventListener("start", () => {
+        this.isRecording = true;
+        this.isPaused = false;
+        this.$emit("start");
+      });
+
+      this.$_mediaRecorder.addEventListener("resume", () => {
+        this.isRecording = true;
+        this.isPaused = false;
+        this.$emit("resume");
+      });
+
+      this.$_mediaRecorder.addEventListener("pause", () => {
+        this.isPaused = true;
+        this.$emit("pause");
+      });
+
+      // Collect the available data into chunks
+      this.$_mediaRecorder.addEventListener(
+        "dataavailable",
+        e => {
+          if (e.data && e.data.size > 0) {
+            this.chunks.push(e.data);
+          }
+        },
+        true
+      );
+
+      // On recording stop get the data and emit the result
+      // than clear all the recording chunks
+      this.$_mediaRecorder.addEventListener(
+        "stop",
+        () => {
+          this.$emit("stop");
+
+          const blobData = new Blob(this.chunks, {
+            type: this.$_mediaRecorder.mimeType
+          });
+          if (blobData.size > 0) {
+            this.$emit("result", blobData);
+          }
+          this.chunks = [];
+          this.isPaused = false;
+          this.isRecording = false;
+
+          this.$_mic.dispose();
+        },
+        true
+      );
+    }
+  },
+};

--- a/src/components/SafariRecorderMixin.js
+++ b/src/components/SafariRecorderMixin.js
@@ -3,6 +3,10 @@ import { loadScripts } from "./loadScripts";
 import StartAudioContext from "startaudiocontext";
 import Tone from "tone";
 
+// https://github.com/Tonejs/Tone.js/issues/341
+// https://github.com/tambien/StartAudioContext
+StartAudioContext(Tone.context);
+
 export default {
   methods: {
     async start() {
@@ -40,10 +44,6 @@ export default {
     async getStream() {
       // const stream = await navigator.mediaDevices.getUserMedia(this.constraints)
       // this.$_stream = stream
-
-      // https://github.com/Tonejs/Tone.js/issues/341
-      // https://github.com/tambien/StartAudioContext
-      StartAudioContext(Tone.context);
 
       // you probably DONT want to connect the microphone
       // directly to the master output because of feedback.

--- a/src/components/loadScripts.js
+++ b/src/components/loadScripts.js
@@ -1,0 +1,134 @@
+/**
+ * Dinamically load script into DOM
+ * @see https://gist.github.com/lidio601/81974ecf4564dbf257f80a969dcbdd5c
+ *
+ * Example usage:
+ * {code}
+
+  require('./loadScript');
+
+  console.log('starting');
+  loadScripts([
+    "https://cdn.jsdelivr.net/npm/opus-media-recorder@latest/OpusMediaRecorder.umd.js",
+    "https://cdn.jsdelivr.net/npm/opus-media-recorder@latest/encoderWorker.umd.js"
+  ], { debug: true })
+    .then(() => console.log("finished"))
+    .catch(console.error);
+ {/code}
+ */
+
+/**
+ * @see https://stackoverflow.com/questions/16839698/jquery-getscript-alternative-in-native-javascript
+ */
+export const loadScript = (
+  source,
+  {
+    beforeEl = false,
+    afterEl = false,
+    async = true,
+    defer = true,
+    debug = false
+  } = {}
+) => {
+  return new Promise((resolve, reject) => {
+    let script = document.createElement("script");
+    const shouldInjectBefore = !afterEl; // defaults to before
+    const scripts = document.getElementsByTagName("script");
+
+    // check whenever this script is not already included!
+    const existingOne = Array.prototype.slice
+      .call(scripts)
+      .filter(elem => elem.src === source);
+
+    if (existingOne.length) {
+      debug && console.warn("loadScript :: skipped because it's already loaded", {
+        source
+      });
+
+      return resolve(existingOne);
+    }
+
+    const prior = beforeEl || (scripts.length > 0 ? scripts[0] : null);
+    const after = afterEl || (scripts.length > 0 ? [scripts.length - 1] : null);
+
+    script.async = async;
+    script.defer = defer;
+
+    function onloadHander(_, isAbort) {
+      if (
+        isAbort ||
+        !script.readyState ||
+        /loaded|complete/.test(script.readyState)
+      ) {
+        script.onload = null;
+        script.onreadystatechange = null;
+        script = undefined;
+
+        if (isAbort) {
+          reject(
+            new Error(`loadScript :: error while loading script from ${script}`)
+          );
+        } else {
+          resolve(script);
+        }
+      }
+    }
+
+    script.onload = onloadHander;
+    script.onreadystatechange = onloadHander;
+
+    script.src = source;
+
+    if (shouldInjectBefore && beforeEl) {
+      prior.parentNode.insertBefore(script, prior);
+    } else if (!shouldInjectBefore && afterEl) {
+      // Note: There is no insertAfter() method.
+      // It can be emulated by combining the insertBefore method with Node.nextSibling.
+      prior.parentNode.insertBefore(script, after.nextSibling);
+    } else {
+      document.head.appendChild(script);
+    }
+  });
+};
+
+export const loadScripts = async (
+  sources,
+  {
+    beforeEl = false,
+    afterEl = false,
+    async = true,
+    defer = true,
+    debug = false
+  } = {}
+) => {
+  // defaults to []
+  sources = sources || [];
+  // ensure that is an array
+  sources = typeof sources.forEach === "function" ? sources : [sources];
+  // if it's empty
+  if (sources.length === 0) {
+    debug && console.log("loadScripts :: ended");
+    return;
+  }
+
+  // include scripts in order
+  const firstScript = sources.shift();
+  debug && console.log("loadScripts :: loading", firstScript);
+
+  return (
+    loadScript(firstScript, { beforeEl, afterEl, async, defer })
+      // recursion here!
+      .then(elem => {
+        debug && console.log("loadScripts :: loaded", firstScript);
+
+        return loadScripts(sources, {
+          // continue injecting the other scripts
+          // after this one
+          afterEl: elem,
+          async,
+          defer,
+          debug
+        });
+      })
+  );
+};


### PR DESCRIPTION
I ported a standalone example I had that uses a polyfill + tone.js to record audio as it wasn't working on Safari.

This still doesn't support video recording (on Safari) but you could look into [this](https://github.com/CameraKit/webm-media-recorder).

For now I just duplicated the existing mixin and renamed it to be used by the video-recorder component, and added the code to check if MediaRecorder is defined to disable it (otherwise it will raise an error after the recording starts).